### PR TITLE
Changing syntax highlighting in docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! #Example
 //!
-//! ```Rust
+//! ```rust
 //! extern crate conshash;
 //!
 //! use std::collections::hash_map::DefaultHasher;


### PR DESCRIPTION
This should make the syntax highlighting work properly on docs.rs :slightly_smiling_face: 